### PR TITLE
Limit to Flask<3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.3.*,!=3.5.*",
-    install_requires=["Flask>=0.12", "semver>=2.10.0,<3.0.0"],
+    install_requires=["Flask>=0.12,<3.0.0", "semver>=2.10.0,<3.0.0"],
     cmdclass={
         "publish": PublishCommand,
     },


### PR DESCRIPTION
Flask 3.0.0 moved a lot of stuff around, not the least dropping `Markup` and pointing users to use `MarkupSafe` for themselves.

Since reworking Flask-PluginKit to be compatible with Flask 3.* seems to be a larger effort (form a cursory glance), I would like to propose to introduce a limit of `Flask>=0.12,<3.0.0` for the time being and making this into a 3.7.3 release.